### PR TITLE
Accept POST requests with JSON body

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,5 +1,5 @@
 
-name: Yfirlestur CI tests
+name: tests
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ mypy.ini
 
 # Pyre type checker
 .pyre/
+
+test.json

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ without error, or `false` if there was a problem.
 
 The `/correct.api` endpoint supports several options:
 
-| Key                           | Type | Default |
-| ----------------------------- | ---- | ------- |
-| annotate\_unparsed\_sentences | bool | true    |
-| suppress_suggestions          | bool | false   |
-| ignore_wordlist               | list | []      |
-| ignore_rules                  | list | []      |
+| Key                           | Type | Default | Explanation
+| ----------------------------- | ---- | ------- | ------------------------------
+| annotate\_unparsed\_sentences | bool | true    | Annotate sentence even when parsing fails
+| suppress_suggestions          | bool | false   | Don't return suggestions
+| ignore_wordlist               | list | []      | Words to accept without comment
+| ignore_rules                  | list | []      | Rules to ignore when annotating
 
 ### From Python
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ and how many of those sentences could be parsed. The `valid` field is
 `true` if the request was correctly formatted and could be processed
 without error, or `false` if there was a problem.
 
+#### Options
+
+The `/correct.api` endpoint supports several options:
+
+| Key                           | Type | Default |
+| ----------------------------- | ---- | ------- |
+| annotate\_unparsed\_sentences | bool | true    |
+| suppress_suggestions          | bool | false   |
+| ignore_wordlist               | list | []      |
+| ignore_rules                  | list | []      |
+
 ### From Python
 
 As an example of accessing the Yfirlestur API from Python, here is

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
 [![Join the chat at https://gitter.im/Greynir/Lobby](https://badges.gitter.im/Greynir/Lobby.svg)](https://gitter.im/Greynir/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build](https://github.com/mideind/Yfirlestur/actions/workflows/python-app.yml/badge.svg)]()
 

--- a/README.md
+++ b/README.md
@@ -210,10 +210,10 @@ managed by Almannarómur. The LT Programme is described
 
 ## Copyright and licensing
 
-Yfirlestur is *copyright © 2021 by Miðeind ehf.*
+Yfirlestur.is is Copyright © 2022 [Miðeind ehf.](https://mideind.is).
 The original author of this software is *Vilhjálmur Þorsteinsson*.
 
-<a href="https://mideind.is"><img src="static/img/mideind-horizontal-small.png" alt="Miðeind ehf." 
+<a href="https://mideind.is"><img src="static/img/mideind-horizontal-small.png" alt="Miðeind ehf."
     width="214" height="66" align="right" style="margin-left:20px; margin-bottom: 20px;"></a>
 
 This software is licensed under the **MIT License**:

--- a/correct.py
+++ b/correct.py
@@ -190,12 +190,15 @@ def check_grammar(
     annotate_unparsed_sentences: bool = True,
     suppress_suggestions: bool = False,
     ignore_wordlist: List = [],
+    ignore_rules: List = []
 ) -> CheckResult:
     """Check the grammar and spelling of the given text and return
     a list of annotated paragraphs, containing sentences, containing
     tokens. The progress_func, if given, will be called periodically
     during processing to indicate progress, with a ratio parameter
     which is a float in the range 0.0..1.0."""
+
+    print(locals())
 
     result = check_with_stats(
         text,
@@ -204,6 +207,7 @@ def check_grammar(
         annotate_unparsed_sentences=annotate_unparsed_sentences,
         suppress_suggestions=suppress_suggestions,
         ignore_wordlist=ignore_wordlist,
+        ignore_rules=ignore_rules,
     )
 
     # Character index of each token within the submitted text,

--- a/correct.py
+++ b/correct.py
@@ -198,8 +198,6 @@ def check_grammar(
     during processing to indicate progress, with a ratio parameter
     which is a float in the range 0.0..1.0."""
 
-    print(locals())
-
     result = check_with_stats(
         text,
         progress_func=progress_func,

--- a/correct.py
+++ b/correct.py
@@ -165,7 +165,7 @@ class NERCorrect(reynir_correct.GreynirCorrect):
 
 def generate_nonce() -> str:
     """Generate a random nonce, consisting of 8 digits"""
-    return "{0:08}".format(random.randint(0, 10 ** 8 - 1))
+    return "{0:08}".format(random.randint(0, 10**8 - 1))
 
 
 def generate_token(original: str, nonce: str) -> str:
@@ -188,6 +188,8 @@ def check_grammar(
     progress_func: Optional[Callable[[float], None]] = None,
     split_paragraphs: bool = True,
     annotate_unparsed_sentences: bool = True,
+    suppress_suggestions: bool = False,
+    ignore_wordlist: List = [],
 ) -> CheckResult:
     """Check the grammar and spelling of the given text and return
     a list of annotated paragraphs, containing sentences, containing
@@ -200,6 +202,8 @@ def check_grammar(
         progress_func=progress_func,
         split_paragraphs=split_paragraphs,
         annotate_unparsed_sentences=annotate_unparsed_sentences,
+        suppress_suggestions=suppress_suggestions,
+        ignore_wordlist=ignore_wordlist,
     )
 
     # Character index of each token within the submitted text,

--- a/main.py
+++ b/main.py
@@ -60,7 +60,8 @@ import re
 import logging
 from datetime import datetime
 
-from flask import Flask, Response, render_template, send_from_directory, jsonify
+from flask import Flask, render_template, send_from_directory, jsonify
+from flask.wrappers import Response
 from flask_caching import Cache  # type: ignore
 from flask_cors import CORS  # type: ignore
 
@@ -122,7 +123,7 @@ def make_pattern(rep_dict: Dict[str, Any]) -> Pattern[str]:
 def multiple_replace(
     string: str, rep_dict: Dict[str, str], pattern: Optional[Pattern[str]] = None
 ) -> str:
-    """ Perform multiple simultaneous replacements within string """
+    """Perform multiple simultaneous replacements within string"""
     if pattern is None:
         pattern = make_pattern(rep_dict)
     return pattern.sub(lambda x: rep_dict[x.group(0)], string)
@@ -134,14 +135,14 @@ _PATTERN_IS = make_pattern(_REP_DICT_IS)
 
 @app.template_filter("format_is")  # type: ignore
 def format_is(r: float, decimals: int = 0) -> str:
-    """ Flask/Jinja2 template filter to format a number for the Icelandic locale """
+    """Flask/Jinja2 template filter to format a number for the Icelandic locale"""
     fmt = "{0:,." + str(decimals) + "f}"
     return multiple_replace(fmt.format(float(r)), _REP_DICT_IS, _PATTERN_IS)
 
 
 @app.template_filter("format_ts")  # type: ignore
 def format_ts(ts: datetime) -> str:
-    """ Flask/Jinja2 template filter to format a timestamp """
+    """Flask/Jinja2 template filter to format a timestamp"""
     return str(ts)[0:19]
 
 
@@ -150,11 +151,11 @@ def format_ts(ts: datetime) -> str:
 def hashed_url_for_static_file(
     endpoint: str, values: Dict[str, Union[int, str]]
 ) -> None:
-    """ Add a ?h=XXX parameter to URLs for static .js and .css files,
-        where XXX is calculated from the file timestamp """
+    """Add a ?h=XXX parameter to URLs for static .js and .css files,
+    where XXX is calculated from the file timestamp"""
 
     def static_file_hash(filename: str) -> int:
-        """ Obtain a timestamp for the given file """
+        """Obtain a timestamp for the given file"""
         return int(os.stat(filename).st_mtime)
 
     if "static" == endpoint or endpoint.endswith(".static"):
@@ -185,20 +186,20 @@ def send_font(path: str):
 # Custom 404 error handler
 @app.errorhandler(404)
 def page_not_found(e: BaseException) -> str:
-    """ Return a custom 404 error """
+    """Return a custom 404 error"""
     return render_template("404.html")
 
 
 # Custom 500 error handler
 @app.errorhandler(500)
 def server_error(e: BaseException) -> str:
-    """ Return a custom 500 error """
+    """Return a custom 500 error"""
     return render_template("500.html")
 
 
 @app.errorhandler(410)
 def resource_gone(e: BaseException) -> Tuple[Response, int]:
-    """ Return a custom 410 GONE error """
+    """Return a custom 410 GONE error"""
     return cast(Response, jsonify(valid=False, error=str(e))), 410
 
 

--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ app.app_context().push()
 
 # Set up caching
 # Caching is disabled if app is invoked via the command line
-cache_type = "simple" if RUNNING_AS_SERVER else "null"
+cache_type = "SimpleCache" if RUNNING_AS_SERVER else "null"
 cache = Cache(app, config={"CACHE_TYPE": cache_type})
 app.config["CACHE"] = cache
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.1
+Flask==2.1.2
 flask-caching>=1.10.1
 psycopg2cffi==2.9.0
 reynir-correct>=3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Flask==2.1.2
 flask-caching>=2.0.0
 Flask-Cors>=3.0.10
-SQLAlchemy==1.4.23
+SQLAlchemy==1.4.39
 psycopg2cffi==2.9.0
-reynir-correct>=3.2.0
+reynir-correct>=3.4.4
 striprtf>=0.0.6
 defusedxml>=0.6.0
 cachetools>=3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 Flask==2.1.2
-flask-caching>=1.10.1
+flask-caching>=2.0.0
+Flask-Cors>=3.0.10
+SQLAlchemy==1.4.23
 psycopg2cffi==2.9.0
 reynir-correct>=3.2.0
-SQLAlchemy==1.4.23
 striprtf>=0.0.6
 defusedxml>=0.6.0
 cachetools>=3.1.1
-Flask-Cors>=3.0.10
 html2text>=2018.1.9
 odfpy>=1.4.1
 pdfminer.six>=20201018

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -35,6 +35,7 @@
 
 from typing import TYPE_CHECKING, Tuple, Dict, Any, Callable, Optional, cast
 
+import logging
 import threading
 import time
 import uuid
@@ -133,9 +134,20 @@ def text_from_request(
         if rq.headers.get("Content-Type") == "text/plain":
             # Accept plain text POSTs, UTF-8 encoded.
             # Example usage:
-            # curl -d @example.txt https://greynir.is/postag.api \
+            # curl -d @example.txt https://yfirlestur.is/correct.api \
             #     --header "Content-Type: text/plain"
             text = rq.data.decode("utf-8")
+        elif rq.headers.get("Content-Type") == "application/json":
+            # Accept JSON POSTs, UTF-8 encoded.
+            # Example usage:
+            # curl -d @example.json https://yfirlestur.is/correct.api \
+            #     --header "Content-Type: application/json"
+            json = rq.json
+            if json is None or not isinstance(json, dict):
+                logging.warning("Invalid JSON in POST request")
+                text = ""
+            else:
+                text = json.get(post_field or "text", "")
         else:
             # Also accept form/url-encoded requests:
             # curl -d "text=Í dag er ágætt veður en mikil hálka er á götum." \

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -131,18 +131,19 @@ def text_from_request(
     be overridden using the post_field parameter.
     """
     if rq.method == "POST":
-        if rq.headers.get("Content-Type") == "text/plain":
+        content_type = rq.headers.get("Content-Type")
+        if content_type == "text/plain":
             # Accept plain text POSTs, UTF-8 encoded.
             # Example usage:
             # curl -d @example.txt https://yfirlestur.is/correct.api \
             #     --header "Content-Type: text/plain"
             text = rq.data.decode("utf-8")
-        elif rq.headers.get("Content-Type") == "application/json":
+        elif content_type == "application/json":
             # Accept JSON POSTs, UTF-8 encoded.
             # Example usage:
             # curl -d @example.json https://yfirlestur.is/correct.api \
             #     --header "Content-Type: application/json"
-            json = rq.json
+            json = rq.get_json(silent=True)
             if json is None or not isinstance(json, dict):
                 logging.warning("Invalid JSON in POST request")
                 text = ""

--- a/routes/api.py
+++ b/routes/api.py
@@ -239,7 +239,7 @@ def feedback(version: int = 1) -> Any:
     return better_jsonify(ok=True)
 
 
-OPTIONS_FLAGS = {
+OPTIONS_FLAGS: Dict[str, str] = {
     "annotate_unparsed_sentences": "bool",
     "suppress_suggestions": "bool",
     "ignore_wordlist": "list",
@@ -249,7 +249,7 @@ OPTIONS_FLAGS = {
 
 def opts_from_request(rq: Request) -> Dict[str, Any]:
     """Extract valid options from a request into dict."""
-    d = dict()
+    d: Dict[str, Any] = dict()
 
     rqd = RequestData(request)
 

--- a/routes/api.py
+++ b/routes/api.py
@@ -242,8 +242,8 @@ def feedback(version: int = 1) -> Any:
 CONFIG_FLAGS = {
     "annotate_unparsed_sentences": "bool",
     "suppress_suggestions": "bool",
-    # "ignore_wordlist": "list",
-    # "ignore_rules": "list",
+    "ignore_wordlist": "list",
+    "ignore_rules": "list",
 }
 
 
@@ -254,9 +254,13 @@ def opts_from_request(rq: Request) -> Dict[str, Any]:
 
     for k, v in CONFIG_FLAGS.items():
         if v == "bool":
-            d[k] = rqd.get_bool(k)
+            b = rqd.get_bool(k)
+            if b is not None:
+                d[k] = b
         elif v == "list":
-            d[k] = rqd.get_list(k)
+            l = rqd.get_list(k)
+            if l is not None:
+                d[k] = rqd.get_list(k)
 
     return d
 
@@ -296,6 +300,9 @@ def correct_sync(version: int = 1) -> Any:
 
     # Retrieve option flags from request
     opts = opts_from_request(request)
+
+    print(opts)
+    print("#########")
 
     # Launch the correction task within a child process and wait for its outcome
     task = ChildTask(**opts)

--- a/routes/api.py
+++ b/routes/api.py
@@ -239,7 +239,7 @@ def feedback(version: int = 1) -> Any:
     return better_jsonify(ok=True)
 
 
-CONFIG_FLAGS = {
+OPTIONS_FLAGS = {
     "annotate_unparsed_sentences": "bool",
     "suppress_suggestions": "bool",
     "ignore_wordlist": "list",
@@ -248,11 +248,12 @@ CONFIG_FLAGS = {
 
 
 def opts_from_request(rq: Request) -> Dict[str, Any]:
+    """Extract valid options from a request into dict."""
     d = dict()
 
     rqd = RequestData(request)
 
-    for k, v in CONFIG_FLAGS.items():
+    for k, v in OPTIONS_FLAGS.items():
         if v == "bool":
             b = rqd.get_bool(k)
             if b is not None:

--- a/routes/api.py
+++ b/routes/api.py
@@ -243,6 +243,7 @@ CONFIG_FLAGS = {
     "annotate_unparsed_sentences": "bool",
     "suppress_suggestions": "bool",
     # "ignore_wordlist": "list",
+    # "ignore_rules": "list",
 }
 
 

--- a/routes/api.py
+++ b/routes/api.py
@@ -302,9 +302,6 @@ def correct_sync(version: int = 1) -> Any:
     # Retrieve option flags from request
     opts = opts_from_request(request)
 
-    print(opts)
-    print("#########")
-
     # Launch the correction task within a child process and wait for its outcome
     task = ChildTask(**opts)
     task.launch(result)

--- a/routes/api.py
+++ b/routes/api.py
@@ -40,7 +40,6 @@ import time
 import threading
 import json
 import uuid
-import logging
 from datetime import datetime, timedelta
 from functools import partial
 
@@ -257,7 +256,7 @@ def opts_from_request(rq: Request) -> Dict[str, Any]:
             d[k] = rqd.get_bool(k)
         elif v == "list":
             d[k] = rqd.get_list(k)
-    print(d)
+
     return d
 
 

--- a/routes/main.py
+++ b/routes/main.py
@@ -26,23 +26,19 @@
         SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-    This module contains the main Flask routes for the Yfirlestur.is
-    web application.
+    This module contains the main routes for the Yfirlestur.is web application.
 
 """
 
-from typing import Any, cast
 
 import platform
 import sys
 
 from flask import render_template, request
 
-import reynir_correct
-
 from reynir import __version__ as greynir_version
 from reynir_correct import __version__ as greynir_correct_version
-from tokenizer.version import __version__ as tokenizer_version
+from tokenizer import __version__ as tokenizer_version
 
 from doc import SUPPORTED_DOC_MIMETYPES
 

--- a/routes/main.py
+++ b/routes/main.py
@@ -27,7 +27,7 @@
 
 
     This module contains the main Flask routes for the Yfirlestur.is
-    web server.
+    web application.
 
 """
 
@@ -48,8 +48,8 @@ from . import routes, text_from_request
 @routes.route("/", methods=["GET"])
 @routes.route("/correct", methods=["GET", "POST"])
 def correct():
-    """ Handler for a page for spelling and grammar correction
-        of user-entered text """
+    """Handler for a page for spelling and grammar correction
+    of user-entered text"""
     try:
         txt = text_from_request(request, post_field="txt", get_field="txt")
     except:
@@ -64,7 +64,7 @@ def correct():
 @routes.route("/about")
 # @max_age(seconds=10 * 60)
 def about():
-    """ Handler for the 'About' page """
+    """Handler for the 'About' page"""
     try:
         reynir_correct_version: str = cast(Any, reynir_correct).__version__
         python_version = "{0} ({1})".format(

--- a/routes/main.py
+++ b/routes/main.py
@@ -40,6 +40,10 @@ from flask import render_template, request
 
 import reynir_correct
 
+from reynir import __version__ as greynir_version
+from reynir_correct import __version__ as greynir_correct_version
+from tokenizer.version import __version__ as tokenizer_version
+
 from doc import SUPPORTED_DOC_MIMETYPES
 
 from . import routes, text_from_request
@@ -66,16 +70,19 @@ def correct():
 def about():
     """Handler for the 'About' page"""
     try:
-        reynir_correct_version: str = cast(Any, reynir_correct).__version__
         python_version = "{0} ({1})".format(
             ".".join(str(n) for n in sys.version_info[:3]),
             platform.python_implementation(),
         )
+        platform_name = platform.system()
     except AttributeError:
-        reynir_correct_version = ""
         python_version = ""
+        platform_name = ""
     return render_template(
         "about.html",
-        reynir_correct_version=reynir_correct_version,
+        greynir_correct_version=greynir_correct_version,
+        greynir_version=greynir_version,
+        tokenizer_version=tokenizer_version,
         python_version=python_version,
+        platform_name=platform_name,
     )

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,48 +1,46 @@
-
 {% extends "container-normal.html" %}
 
 {% block styles %}
 
-<link href="{{ url_for('static', filename='css/main-bootstrap.css') }}"
-   rel='stylesheet' type='text/css'>
+<link href="{{ url_for('static', filename='css/main-bootstrap.css') }}" rel='stylesheet' type='text/css'>
 
 <style type="text/css">
-
-.lead {
-   font-size: 22px;
-}
-.lead b {
-   font-style: italic;
-}
-
-@media (min-width: 768px) {
    .lead {
-      font-size: 34px;
+      font-size: 22px;
    }
+
    .lead b {
       font-style: italic;
    }
-}
 
-blockquote {
-   font-size: 0.9em;
-}
+   @media (min-width: 768px) {
+      .lead {
+         font-size: 34px;
+      }
 
-blockquote cite {
-   margin-left: 0.2rem;
-}
+      .lead b {
+         font-style: italic;
+      }
+   }
 
-li.list-group-item p i {
-   display: inline-block;
-   white-space: nowrap;
-}
+   blockquote {
+      font-size: 0.9em;
+   }
 
-p.small {
-   margin-top: 2px;
-   margin-bottom: 2px;
-   font-size: 14px;
-}
+   blockquote cite {
+      margin-left: 0.2rem;
+   }
 
+   li.list-group-item p i {
+      display: inline-block;
+      white-space: nowrap;
+   }
+
+   p.small {
+      margin-top: 2px;
+      margin-bottom: 2px;
+      font-size: 14px;
+   }
 </style>
 
 {% endblock %}
@@ -52,93 +50,105 @@ p.small {
 <div class="panel panel-warning">
    <div class="panel-heading"><span class="glyphicon glyphicon-info"></span></div>
    <div class="panel-body">
-      <div style="float:right"><img class="villi img-rounded"
-      src="{{ url_for('static', filename='img/vth.jpg') }}" width="80" height="97"></div>
+      <div style="float:right"><img class="villi img-rounded" src="{{ url_for('static', filename='img/vth.jpg') }}"
+            width="80" height="97"></div>
       <p class="lead"><b>Yfirlestur.is</b> er vefur sem rýnir íslenskan texta.</p>
       <p class="author"><i>Upphafsmaður Yfirlestrar.is<br>er Vilhjálmur Þorsteinsson</i></p>
    </div>
    <ul class="list-group">
-   <li class="list-group-item">
-      <p>
-         Yfirlestur.is les íslenskan texta og finnur&mdash;með sjálfvirkum hætti&mdash;ýmislegt
-         sem betur mætti fara í stafsetningu og málfari.
-      </p>
-      <p>
-         Vefurinn bendir á <b>stafsetningarvillur</b>, þ.e. orðmyndir sem ekki finnast
-         í orðabókum (einkum <a href="https://bin.arnastofnun.is">Beygingarlýsingu íslensks nútímamáls</a>)
-         og eru jafnframt ólíklegar til að vera gild samsett orð.
-         Einnig finnur hann <b>samhengisháðar villur</b>, svo sem <i>að ýmsu ?leiti</i>
-         og <i>á næsta ?leyti</i>, tvöfölduð orð (<i>eru eru</i>), ranga notkun hástafa
-         og lágstafa (<i>Þetta er ?Franskt rauðvín</i>), o.m.fl.
-      </p>
-      <p>
-         Markverðasta nýjungin er þó sú að Yfirlestur.is kemur auga á ýmis
-         <b>málfræðileg atriði</b> sem betur mættu fara. Til dæmis finnur vefurinn
-         tilvik þar sem sagnir eru notaðar með frumlagi í öðru falli en
-         réttast þykir, svo sem <i>?Manninum á verkstæðinu vantaði hamar</i> og
-         <i>?Litla drenginn með rauðu slaufuna hlakkaði til jólanna</i>. Þá grípur
-         hann misræmi milli eintölu og fleirtölu á borð við
-         <i>Fjöldi stuðningsmanna KR ?fögnuðu að leik loknum</i> og
-         <i>Einn af leiðangursmönnunum ?sögðu að ferðin hefði verið erfið.</i>
-      </p>
-      <p>
-         Þótt Yfirlestur.is sé að ýmsu leyti öflugri en sambærileg tól
-         sem áður hafa boðist fyrir íslensku er hann ekki fullkominn og á
-         eftir að þróast áfram í samstarfi við notendur. Ábendingar um endurbætur
-         eru vel þegnar í tölvupósti á <a href="mailto:mideind@mideind.is">mideind@mideind.is</a>.
-      </p>
-      <p>
-         Yfirlestur.is er meðal afurða <a href="https://mideind.is/greynir.html">Greynis-verkefnisins</a>,
-         sem unnið er að hjá <a href="https://mideind.is">Miðeind ehf.</a>
-      </p>
-   </li>
-   <li class="list-group-item">
-      <p><a href="https://mideind.is"><img src="{{ url_for('static', filename='img/mideind-horizontal-small.png') }}"
-         width="200" height="62" style="margin-top:14px; float:left; margin-right: 28px; margin-bottom: 18px;"></a>
-      </p>
-      <p>
-         <b>Höfundaréttur &copy; 2021 Miðeind ehf.</b>
-         <br>
-         <span>[Þróunarútgáfa]</span> <!-- This text is replaced by a date stamp in deploy.sh -->
-         &bull;
-         <span>[Git-útgáfa]</span> <!-- This text is replaced by git commit hash in deploy.sh -->
-{%- if reynir_correct_version %}
-         &bull;
-         <span>GreynirCorrect {{ reynir_correct_version }}</span>
-{%- endif -%}
-{%- if python_version %}
-         &bull;
-         <span>Python {{ python_version }}</a></span>
-{%- endif -%}
-      </p>
-      <p>
-         Yfirlestur.is byggir á málrýnihugbúnaðinum
-         <a href="https://github.com/mideind/GreynirCorrect">GreynirCorrect</a>,
-         sem er opinn og frjáls
-         <a href="https://pypi.org/project/reynir-correct/" target="_blank">Python-pakki</a>.
-         Bæði Yfirlestur.is og GreynirCorrect eru undir
-         <a href="https://github.com/mideind/GreynirCorrect/blob/master/LICENSE">MIT hugbúnaðarleyfi</a>.
-      </p>
-   </li>
-   <li class="list-group-item">
-      <p class="small">
-         Yfirlestur.is nýtir hugbúnað og gögn sem þróuð eru sem hluti af
-         <a href="https://www.stjornarradid.is/lisalib/getfile.aspx?itemid=56f6368e-54f0-11e7-941a-005056bc530c">5
-            ára máltækniáætlun stjórnvalda</a> til stuðnings máltækni fyrir íslensku.
-      </p>
-   </li>
-   <li class="list-group-item">
-      <p class="small">
-         Yfirlestur.is byggir á opnum gögnum
-         <a href="http://bin.arnastofnun.is" target="_blank"><i>Beygingarlýsingar
-         íslensks nútímamáls</i></a> (BÍN).
-         Höfundarrétt að BÍN á
-         <a href="http://www.arnastofnun.is" target="_blank"><i>Stofnun Árna Magnússonar
-         í íslenskum fræðum</i></a>. BÍN er notuð í Greyni og á þessum vef samkvæmt
-         <a href="http://bin.arnastofnun.is/gogn/skilmalar/"
-         target="_blank">skilmálum SÁM</a>.
-      </p>
-   </li>
+      <li class="list-group-item">
+         <p>
+            Yfirlestur.is les íslenskan texta og finnur&mdash;með sjálfvirkum hætti&mdash;ýmislegt
+            sem betur mætti fara í stafsetningu og málfari.
+         </p>
+         <p>
+            Vefurinn bendir á <b>stafsetningarvillur</b>, þ.e. orðmyndir sem ekki finnast
+            í orðabókum (einkum <a href="https://bin.arnastofnun.is">Beygingarlýsingu íslensks nútímamáls</a>)
+            og eru jafnframt ólíklegar til að vera gild samsett orð.
+            Einnig finnur hann <b>samhengisháðar villur</b>, svo sem <i>að ýmsu ?leiti</i>
+            og <i>á næsta ?leyti</i>, tvöfölduð orð (<i>eru eru</i>), ranga notkun hástafa
+            og lágstafa (<i>Þetta er ?Franskt rauðvín</i>), o.m.fl.
+         </p>
+         <p>
+            Markverðasta nýjungin er þó sú að Yfirlestur.is kemur auga á ýmis
+            <b>málfræðileg atriði</b> sem betur mættu fara. Til dæmis finnur vefurinn
+            tilvik þar sem sagnir eru notaðar með frumlagi í öðru falli en
+            réttast þykir, svo sem <i>?Manninum á verkstæðinu vantaði hamar</i> og
+            <i>?Litla drenginn með rauðu slaufuna hlakkaði til jólanna</i>. Þá grípur
+            hann misræmi milli eintölu og fleirtölu á borð við
+            <i>Fjöldi stuðningsmanna KR ?fögnuðu að leik loknum</i> og
+            <i>Einn af leiðangursmönnunum ?sögðu að ferðin hefði verið erfið.</i>
+         </p>
+         <p>
+            Þótt Yfirlestur.is sé að ýmsu leyti öflugri en sambærileg tól
+            sem áður hafa boðist fyrir íslensku er hann ekki fullkominn og á
+            eftir að þróast áfram í samstarfi við notendur. Ábendingar um endurbætur
+            eru vel þegnar í tölvupósti á <a href="mailto:mideind@mideind.is">mideind@mideind.is</a>.
+         </p>
+         <p>
+            Yfirlestur.is er meðal afurða <a href="https://mideind.is/greynir.html">Greynis-verkefnisins</a>,
+            sem unnið er að hjá <a href="https://mideind.is">Miðeind ehf.</a>
+         </p>
+      </li>
+      <li class="list-group-item">
+         <p><a href="https://mideind.is"><img src="{{ url_for('static', filename='img/mideind-horizontal-small.png') }}"
+                  width="200" height="62"
+                  style="margin-top:14px; float:left; margin-right: 28px; margin-bottom: 18px;"></a>
+         </p>
+         <p>
+            <b>Höfundaréttur &copy; 2022 Miðeind ehf.</b>
+            <br>
+            <span>[Þróunarútgáfa]</span> <!-- This text is replaced by a date stamp in deploy.sh -->
+            &bull;
+            <span>[Git-útgáfa]</span> <!-- This text is replaced by git commit hash in deploy.sh -->
+            {%- if greynir_correct_version %}
+            &bull;
+            <span>GreynirCorrect {{ greynir_correct_version }}</span>
+            {%- endif -%}
+            {%- if greynir_version %}
+            &bull;
+            <span>Greynir {{ greynir_version }}</span>
+            {%- endif -%}
+            {%- if tokenizer_version %}
+            &bull;
+            <span>Tokenizer {{ tokenizer_version }}</span>
+            {%- endif -%}
+            {%- if python_version %}
+            &bull;
+            <span>Python {{ python_version }}</a></span>
+            {%- endif -%}
+            {%- if platform_name %}
+            &bull;
+            <span>{{ platform_name }}</a></span>
+            {%- endif -%}
+         </p>
+         <p>
+            Yfirlestur.is byggir á málrýnihugbúnaðinum
+            <a href="https://github.com/mideind/GreynirCorrect">GreynirCorrect</a>,
+            sem er opinn og frjáls
+            <a href="https://pypi.org/project/reynir-correct/" target="_blank">Python-pakki</a>.
+            Bæði Yfirlestur.is og GreynirCorrect eru undir
+            <a href="https://github.com/mideind/GreynirCorrect/blob/master/LICENSE">MIT hugbúnaðarleyfi</a>.
+         </p>
+      </li>
+      <li class="list-group-item">
+         <p class="small">
+            Yfirlestur.is nýtir hugbúnað og gögn sem þróuð eru sem hluti af
+            <a href="https://www.stjornarradid.is/lisalib/getfile.aspx?itemid=56f6368e-54f0-11e7-941a-005056bc530c">5
+               ára máltækniáætlun stjórnvalda</a> til stuðnings máltækni fyrir íslensku.
+         </p>
+      </li>
+      <li class="list-group-item">
+         <p class="small">
+            Yfirlestur.is byggir á opnum gögnum
+            <a href="http://bin.arnastofnun.is" target="_blank"><i>Beygingarlýsingar
+                  íslensks nútímamáls</i></a> (BÍN).
+            Höfundarrétt að BÍN á
+            <a href="http://www.arnastofnun.is" target="_blank"><i>Stofnun Árna Magnússonar
+                  í íslenskum fræðum</i></a>. BÍN er notuð í Greyni og á þessum vef samkvæmt
+            <a href="http://bin.arnastofnun.is/gogn/skilmalar/" target="_blank">skilmálum SÁM</a>.
+         </p>
+      </li>
    </ul>
 </div>
 
@@ -158,4 +168,3 @@ p.small {
 </script>
 
 {% endblock %}
-

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -92,6 +92,7 @@ def test_api_async_routes(client: FlaskClient):
     assert resp.content_type.startswith(JSON_MIME_TYPE)
     assert isinstance(resp.json, dict)
     assert "progress" in resp.json and isinstance(resp.json["progress"], float)
+    assert resp.headers["Location"].startswith("/status/")
 
 
 def checking(text: str, real: List[int]) -> None:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -44,15 +44,16 @@ from settings import *  # noqa
 
 # from pprint import pprint
 
+
 def checking(text: str, real: List[int]) -> None:
     resp = check_grammar(text)
-    i = [ i.get("i", 0) for i in resp[0][0][0]['tokens'] ] # t.original is in i["o"]
-    #if real != i:
+    i = [i.get("i", 0) for i in resp[0][0][0]["tokens"]]  # t.original is in i["o"]
+    # if real != i:
     #    print(text)
     #    print(f"Result: {i}")
     #    print(f"Real:   {real}")
     #    pprint(resp)
-    #else:
+    # else:
     #    pprint(resp)
     assert real == i
 
@@ -72,7 +73,7 @@ def test_character_spans() -> None:
     text = "Charles Parkton."
     real = [0, 15]
     checking(text, real)
-    
+
     text = "Hér er Nanna."
     real = [0, 3, 6, 12]
     checking(text, real)
@@ -87,7 +88,7 @@ def test_character_spans() -> None:
     checking(text, real)
 
     text = "Hér er Óskar von í dag."
-    real = [0, 3, 6, 16, 16, 18, 22]        # First token retains the original text
+    real = [0, 3, 6, 16, 16, 18, 22]  # First token retains the original text
     checking(text, real)
 
     # MW compound tests
@@ -104,7 +105,7 @@ def test_character_spans() -> None:
     checking(text, real)
 
     text = "Ég er katta -og hundakona."
-    real = [0, 2, 5, 11, 15, 25]         # TODO Ekki sameinað í einn tóka!
+    real = [0, 2, 5, 11, 15, 25]  # TODO Ekki sameinað í einn tóka!
     checking(text, real)
 
     # MWE tests
@@ -116,17 +117,19 @@ def test_character_spans() -> None:
     real = [0, 2, 8, 12, 18, 23]
     checking(text, real)
 
-    # amount tests 
+    # amount tests
     text = "Ég á 500 milljónir króna."
     real = [0, 2, 4, 24]
     checking(text, real)
 
     # Deletion tests
     text = "Ég á á."
-    real = [0, 2, 4, 6]     # Ekki lengur tekið sjálfkrafa út, bara merkt sem möguleg villa
+    real = [0, 2, 4, 6]  # Ekki lengur tekið sjálfkrafa út, bara merkt sem möguleg villa
     checking(text, real)
 
-    text = "Ég datt datt."  # Núna sameinað í einn tóka og stungið upp á að taka annan út
+    text = (
+        "Ég datt datt."  # Núna sameinað í einn tóka og stungið upp á að taka annan út
+    )
     real = [0, 2, 12]
     checking(text, real)
 
@@ -155,7 +158,7 @@ def test_character_spans() -> None:
     text = "Ég er kvennhatari."
     real = [0, 2, 5, 17]
     checking(text, real)
-    
+
     # Split compounds
     text = "Hér er ein birni."
     real = [0, 3, 6, 16]
@@ -170,6 +173,3 @@ def test_character_spans() -> None:
     text = "Ég varð afar stór."
     real = [0, 2, 7, 12, 17]
     checking(text, real)
-
-
-

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -67,22 +67,77 @@ def test_html_page_routes(client: FlaskClient):
         assert resp.content_length > 100
 
 
+def verify(resp):
+    """Verify response from /correct.api sync route."""
+    assert resp.status_code == 200
+    assert resp.content_type.startswith(JSON_MIME_TYPE)
+    assert resp.json and isinstance(resp.json, dict)
+    assert resp.json["valid"] == True
+    assert "result" in resp.json and isinstance(resp.json["result"], list)
+    assert "stats" in resp.json and isinstance(resp.json["stats"], dict)
+    assert "text" in resp.json and isinstance(resp.json["text"], str)
+
+
+def post_correct_request(
+    client: FlaskClient, text: str, opts: Dict = {}, json=False
+) -> Response:
+    payload = {"text": text}
+    payload.update(opts)
+    if json:
+        return client.post("/correct.api", json=payload)
+    else:
+        return client.post("/correct.api", data=payload)
+
+
 def test_api_sync_routes(client: FlaskClient):
     """Test synchronous API routes in web application."""
+    sent = "Þetta er prufa."
 
-    def verify(resp):
-        assert resp.status_code == 200
-        assert resp.content_type.startswith(JSON_MIME_TYPE)
-        assert isinstance(resp.json, dict)
-        assert resp.json["valid"] == True
-        assert "result" in resp.json and isinstance(resp.json["result"], list)
-        assert "stats" in resp.json and isinstance(resp.json["stats"], dict)
-        assert "text" in resp.json and isinstance(resp.json["text"], str)
+    # www form url-encoded POST request
+    resp = post_correct_request(client, sent, json=False)
+    verify(resp)
 
-    resp = client.post("/correct.api", data={"text": "Þetta er prufa."})
+    # JSON POST request
+    resp = post_correct_request(client, sent, json=True)
     verify(resp)
-    resp = client.post("/correct.api", json={"text": "Þetta er prufa."})
+
+
+def test_api_correct_sync_route_with_options(client: FlaskClient):
+    # Test annotate_unparsed_sentences=False
+    SENT1 = "Ég kannaði firðinum ásamt hún."
+    resp = post_correct_request(
+        client, SENT1, opts={"annotate_unparsed_sentences": False}, json=False
+    )
     verify(resp)
+    assert len(resp.json["result"][0][0]["annotations"]) == 0
+
+    resp = post_correct_request(
+        client, SENT1, opts={"annotate_unparsed_sentences": True}, json=False
+    )
+    verify(resp)
+    assert len(resp.json["result"][0][0]["annotations"]) == 1
+
+    # Test suppress_suggestions=True
+    SENT2 = "Það var gott að koma tímalega á áfangastað."
+    resp = post_correct_request(
+        client, SENT2, opts={"suppress_suggestions": True}, json=False
+    )
+    verify(resp)
+    assert len(resp.json["result"][0][0]["annotations"]) == 0
+
+    resp = post_correct_request(
+        client, SENT2, opts={"suppress_suggestions": False}, json=False
+    )
+    verify(resp)
+    assert len(resp.json["result"][0][0]["annotations"]) == 1
+
+    # Test ignore_wordlist
+    # SENT3 = "Það var flargor í gær."
+    # W2IGN = ["flargor"]
+    # resp = post_correct_request(
+    #     client, SENT1, opts={"ignore_wordlist": W2IGN}, json=True
+    # )
+    # verify(resp)
 
 
 def test_api_async_routes(client: FlaskClient):
@@ -95,7 +150,7 @@ def test_api_async_routes(client: FlaskClient):
     assert resp.headers["Location"].startswith("/status/")
 
 
-def checking(text: str, real: List[int]) -> None:
+def verify_char_spans(text: str, real: List[int]) -> None:
     resp = check_grammar(text)
     i = [i.get("i", 0) for i in resp[0][0][0]["tokens"]]  # t.original is in i["o"]
     # if real != i:
@@ -113,113 +168,113 @@ def test_character_spans() -> None:
     # Only 'normal' tokens
     text = "Ég á hest."
     real = [0, 2, 4, 9]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Person token tests
     text = "Á Clinton."
     real = [0, 1, 9]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Charles Parkton."
     real = [0, 15]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Hér er Nanna."
     real = [0, 3, 6, 12]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Hér er Maríanna Gvendardóttir."
     real = [0, 3, 6, 29]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Entity tokens
     text = "Hér er von Óskar."
     real = [0, 3, 6, 10, 16]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Hér er Óskar von í dag."
     real = [0, 3, 6, 16, 16, 18, 22]  # First token retains the original text
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # MW compound tests
     text = "Ég er umhverfis- og auðlindaráðherra."
     real = [0, 2, 5, 36]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Við erum þingkonur og -menn."
     real = [0, 3, 8, 18, 21, 27]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Ég er umhverfis-og auðlindaráðherra."
     real = [0, 2, 5, 35]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Ég er katta -og hundakona."
     real = [0, 2, 5, 11, 15, 25]  # TODO Ekki sameinað í einn tóka!
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # MWE tests
     text = "Ég á meðal annars hest."
     real = [0, 2, 4, 17, 22]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Ég borða með bestu list."
     real = [0, 2, 8, 12, 18, 23]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # amount tests
     text = "Ég á 500 milljónir króna."
     real = [0, 2, 4, 24]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Deletion tests
     text = "Ég á á."
     real = [0, 2, 4, 6]  # Ekki lengur tekið sjálfkrafa út, bara merkt sem möguleg villa
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = (
         "Ég datt datt."  # Núna sameinað í einn tóka og stungið upp á að taka annan út
     )
     real = [0, 2, 12]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # E-mail
     text = "Hér er valid@email.com í gangi."
     real = [0, 3, 6, 22, 24, 30]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Wrong compounds
     # af hverju -> 'af' retains the original token text,
     # 'hverju' has original set to empty
     text = "Ég veit afhverju fuglinn galar."
     real = [0, 2, 7, 16, 16, 24, 30]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Wrong formers
     text = "Ég á fjölnotapoka."
     real = [0, 2, 4, 17, 17]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Free morphemes
     text = "Ég er ofgamall."
     real = [0, 2, 5, 14, 14]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     text = "Ég er kvennhatari."
     real = [0, 2, 5, 17]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Split compounds
     text = "Hér er ein birni."
     real = [0, 3, 6, 16]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Spelling errors
     text = "Ég varð fyri bíl."
     real = [0, 2, 7, 12, 16]
-    checking(text, real)
+    verify_char_spans(text, real)
 
     # Ambiguous phrases
     text = "Ég varð afar stór."
     real = [0, 2, 7, 12, 17]
-    checking(text, real)
+    verify_char_spans(text, real)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -109,13 +109,13 @@ def test_api_correct_sync_route_with_options(client: FlaskClient):
         client, SENT1, opts={"annotate_unparsed_sentences": False}, json=False
     )
     verify(resp)
-    assert len(resp.json["result"][0][0]["annotations"]) == 0
+    assert resp.json and len(resp.json["result"][0][0]["annotations"]) == 0
 
     resp = post_correct_request(
         client, SENT1, opts={"annotate_unparsed_sentences": True}, json=False
     )
     verify(resp)
-    assert len(resp.json["result"][0][0]["annotations"]) == 1
+    assert resp.json and len(resp.json["result"][0][0]["annotations"]) == 1
 
     # Test suppress_suggestions=True
     SENT2 = "Það var gott að koma tímalega á áfangastað."
@@ -123,13 +123,13 @@ def test_api_correct_sync_route_with_options(client: FlaskClient):
         client, SENT2, opts={"suppress_suggestions": True}, json=False
     )
     verify(resp)
-    assert len(resp.json["result"][0][0]["annotations"]) == 0
+    assert resp.json and len(resp.json["result"][0][0]["annotations"]) == 0
 
     resp = post_correct_request(
         client, SENT2, opts={"suppress_suggestions": False}, json=False
     )
     verify(resp)
-    assert len(resp.json["result"][0][0]["annotations"]) == 1
+    assert resp.json and len(resp.json["result"][0][0]["annotations"]) == 1
 
     # Test ignore_wordlist
     # SENT3 = "Það var flargor í gær."


### PR DESCRIPTION
* The correct.api endpoint now supports JSON body in POST request (#6):

The JSON should have the format:
````
{
    "text": "Textinn til að lesa yfir."
}
````
````
curl -d @example.json https://yfirlestur.is/correct.api --header "Content-Type: application/json"
````

* The correct.api endpoint now supports several configurable options: `annotate_unparsed_sentences` (bool), `suppress_suggestions` (bool), `ignore_wordlist` (list), `ignore_rules` (list). These options can be provided either via a www form encoded POST request or a POSTed JSON dict :
````
{
    "text": "...",
    "annotate_unparsed_sentences": false,
    "suppress_suggestions": true,
    "ignore_wordlist": ["florg", "smorg", "glorg"],
    "ignore_rules": ["P_WRONG_CASE"]
}
````
````
curl -d @example.json https://yfirlestur.is/correct.api --header "Content-Type: application/json"
````
* Many tests added for the abovementioned functionality
* Various other Flask test client tests to verify that all web routes are functioning correctly
* About page now shows Tokenizer, Greynir version + platform name, like https://greynir.is/about
* Updated documentation to reflect these changes
* Various linter fixes and formatting (black + others)
