### PR TITLE
Flask 2.3.2 migration

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install package dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
+[![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)
 ![Release](https://shields.io/github/v/release/mideind/Yfirlestur?display_name=tag)
 [![Build](https://github.com/mideind/Yfirlestur/actions/workflows/python-app.yml/badge.svg)]()
 
@@ -10,8 +10,8 @@
 
 ### Spelling and grammar correction for Icelandic
 
-*Yfirlestur.is* is a public website where you can enter or submit your Icelandic text
-and have it checked for spelling and grammar errors.
+*Yfirlestur.is* is a web application where you can enter or submit
+Icelandic text and have it checked for spelling and grammar errors.
 
 The tool also gives hints on words and structures that might not be appropriate,
 depending on the intended audience for the text.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-Flask==2.2.2
-flask-caching>=2.0.0
+Flask==2.3.2
+flask-caching>=2.0.2
 Flask-Cors>=3.0.10
-SQLAlchemy==1.4.45
+SQLAlchemy==1.4.48
 sqlalchemy2-stubs>=0.0.2a30
 psycopg2cffi==2.9.0
 reynir-correct>=3.4.6
 striprtf>=0.0.22
 defusedxml>=0.7.1
-cachetools>=5.2.0
+cachetools>=5.3.0
 html2text>=2020.1.16
 odfpy>=1.4.1
 pdfminer.six>=20221105

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -184,16 +184,7 @@ def fancy_url_for(*args: Any, **kwargs: Any) -> str:
     return url_for(*args, **kwargs)
 
 
-# Mypy/Pylance shenanigans for type checking of @routes.before_app_first_request
-FirstRequestFunc = Callable[[], None]
-before_app_first_request = cast(
-    Callable[[FirstRequestFunc], FirstRequestFunc],
-    cast(Any, routes).before_app_first_request,
-)
-
-
-@before_app_first_request
-def before_first_request() -> None:
+def start_task_cleanup_thread() -> None:
     """Start a background thread that cleans up old tasks"""
 
     def clean_old_tasks() -> None:

--- a/routes/api.py
+++ b/routes/api.py
@@ -587,8 +587,7 @@ def get_process_status(process: str):
     return ChildTask.get_status(process)
 
 
-@routes.before_app_first_request  # type: ignore
-def delete_old_child_tasks() -> None:
+def start_delete_old_child_tasks_thread() -> None:
     """Start a background thread that cleans up old tasks"""
 
     def delete_tasks() -> None:


### PR DESCRIPTION
* Migrated to Flask 2.3.2
* Removed deprecated before_first_request decorators for task cleanup threads
* Updated other dependencies
* Now requires Python 3.8+